### PR TITLE
[FEATURE] Ensure proxy bin is moved to vendor/bin

### DIFF
--- a/bin/phpstorm-docker-proxy
+++ b/bin/phpstorm-docker-proxy
@@ -3,6 +3,6 @@
 
 namespace Shira\PhpStormDockerProxy;
 
-require __DIR__ . '/../vendor/autoload.php';
+require $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
 
 exit((new Cli())->run($argv));

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
         "psr-4": {
             "Shira\\PhpStormDockerProxy\\": "src"
         }
-    }
+    },
+    "bin": [
+        "bin/phpstorm-docker-proxy"
+    ]
 }


### PR DESCRIPTION
This PR ensures that the binary is not moved to vendor/bin when the package is installed.

@see https://getcomposer.org/doc/articles/vendor-binaries.md